### PR TITLE
Combined "booktitle" field into the journal field

### DIFF
--- a/src/static/js/index.js
+++ b/src/static/js/index.js
@@ -135,7 +135,7 @@ function parseBibTeX(bibText) {
         type,
         authors,
         title: fields.title || "",
-        journal: fields.journal || "",
+        journal: fields.journal || fields.booktitle || "",
         year: fields.year || "",
         month: fields.month || "",
         volume: fields.volume || "",


### PR DESCRIPTION
I combined the "book title" and the "journal" fields of parsed bibtex entries so when the webpage can find the venue name when printing the publication info.